### PR TITLE
feat: Configure cdk-nag

### DIFF
--- a/bin/app.ts
+++ b/bin/app.ts
@@ -1,6 +1,11 @@
 import * as cdk from "aws-cdk-lib";
 import { Aspects } from "aws-cdk-lib";
-import { AwsSolutionsChecks } from "cdk-nag";
+import {
+  AwsSolutionsChecks,
+  HIPAASecurityChecks,
+  NIST80053R5Checks,
+  PCIDSS321Checks,
+} from "cdk-nag";
 import { MyProjectStack } from "src/stacks/project";
 
 const app = new cdk.App();
@@ -17,21 +22,23 @@ const checks = [
   // Check for HIPAA Security compliance.
   // Based on the HIPAA Security AWS operational best practices:
   // https://docs.aws.amazon.com/config/latest/developerguide/operational-best-practices-for-hipaa_security.html
-  // new HIPAASecurityChecks({ verbose: true }),
+  new HIPAASecurityChecks({ verbose: true }),
 
   // Check for PCI DSS 3.2.1 compliance.
   // Based on the PCI DSS 3.2.1 AWS operational best practices:
   // https://docs.aws.amazon.com/config/latest/developerguide/operational-best-practices-for-pci-dss.html
-  // new PCIDSS321Checks({ verbose: true }),
+  new PCIDSS321Checks({ verbose: true }),
 
   // Check for NIST 800-53 rev 5 compliance.
   // Based on the NIST 800-53 rev 5 AWS operational best practices:
   // https://docs.aws.amazon.com/config/latest/developerguide/operational-best-practices-for-nist-800-53_rev_5.html
-  // new NIST80053R5Checks({ verbose: true }),
+  new NIST80053R5Checks({ verbose: true }),
 ];
 
-for (const check of checks) {
-  Aspects.of(app).add(check);
+if (process.env.NAG) {
+  for (const check of checks) {
+    Aspects.of(app).add(check);
+  }
 }
 
 app.synth();

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "@tsconfig/node20": "20.1.4",
     "aws-cdk": "2.134.0",
     "aws-cdk-lib": "2.134.0",
-    "cdk-nag": "2.28.77",
+    "cdk-nag": "2.28.78",
     "constructs": "10.3.0",
     "ts-node": "10.9.2",
     "tsconfig-paths": "4.2.0",

--- a/typings/node.d.ts
+++ b/typings/node.d.ts
@@ -6,5 +6,6 @@ declare namespace NodeJS {
     CDK_DEFAULT_ACCOUNT: string;
     CDK_DEFAULT_REGION: string;
     GITHUB_SHA: string;
+    NAG: string;
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1505,10 +1505,10 @@ case@1.6.3:
   resolved "https://registry.yarnpkg.com/case/-/case-1.6.3.tgz#0a4386e3e9825351ca2e6216c60467ff5f1ea1c9"
   integrity sha512-mzDSXIPaFwVDvZAHqZ9VlbyF4yyXRuX6IvB06WvPYkqJVO24kX1PPhv9bfpKNFZyxYFmmgo03HUiD8iklmJYRQ==
 
-cdk-nag@2.28.77:
-  version "2.28.77"
-  resolved "https://registry.yarnpkg.com/cdk-nag/-/cdk-nag-2.28.77.tgz#85062cc7e3902b77a80c13e2e293584d27121cc2"
-  integrity sha512-sIfEtMscT6PuBZC1ExLAWXGMTNTTpAFRhvN94ort5bgxwEEvOCrMWIJnYPscC9tpJgXFI5p334lSiHYmEB3eGg==
+cdk-nag@2.28.78:
+  version "2.28.78"
+  resolved "https://registry.yarnpkg.com/cdk-nag/-/cdk-nag-2.28.78.tgz#6df20752f859d1d6d5920b60473a3abfaa712267"
+  integrity sha512-5lDDJ+/IxXYIZFW6BxYv7MKnhJa/og45gjr/XrVM7ffy0kmpArHtEkkjYRIegWOCQEonqmEjlelyaThR1PZZwg==
 
 chalk@5.3.0, chalk@^5.3.0:
   version "5.3.0"


### PR DESCRIPTION
To run the checks included by cdk-nag, set use the `NAG` environment variable into '1'.

e.g.

```shell
$ NAG=1 make synth
```